### PR TITLE
Adding `-h` support, passing args to `git log`

### DIFF
--- a/git-author-stats
+++ b/git-author-stats
@@ -6,12 +6,14 @@ if [[ "$1" == '--raw' ]]; then
 fi
 
 author=$1
-if [[ -z "$author" ]]; then
-    echo "Usage: git author-stats [author name]"
+shift
+if [[ -z "$author" || "$author" == "--help" || "$author" == "-h" ]]; then
+    echo "Usage: git author-stats <author name> [extra git log params]"
+    echo "Example: git author-stats $USER --since=2017-01-01 --until=2017-01-31"
     exit
 fi
 
-git log --author="$author" --pretty=tformat: --numstat | awk -v RAW=$RAW '{
+git log --author="$author" --pretty=tformat: --numstat "$@" | awk -v RAW=$RAW '{
     added    += $1;
     removed  += $2;
     modified += $1 - -$2;


### PR DESCRIPTION
Showing a help message on `-h` or `--help` is always good. (Note: if launched through `git author-stats --help`, `git` itself will try to open the manpage, which will fail anyway.)

Also passing the arguments to `git log`, which allows some customization, such as restricting for a sub path or restricting a date range.